### PR TITLE
add expect_continue behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,3 +95,6 @@ DEPENDENCIES
   shoulda (~> 3.5.0)
   shoulda-context (~> 1.2.1)
   test-unit (~> 2.5.5)
+
+BUNDLED WITH
+   1.10.3

--- a/lib/expect/behavior.rb
+++ b/lib/expect/behavior.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'expect/match'
 require 'expect/timeout_error'
 
@@ -13,8 +12,11 @@ module Behavior
 
     attr_reader :exp_match
     attr_accessor :exp_timeout_sec
+    attr_accessor :exp_sleep_interval_sec
 
     EXP_TIMEOUT_SEC_DEFAULT = 10
+    EXP_SLEEP_INTERVAL_SEC_DEFAULT = 0.1
+
     def expect(&block)
       #pre-action
       initialize_expect if @__exp_buffer.nil?
@@ -41,8 +43,9 @@ module Behavior
         @exp_match_registry.each_pair do |expr, block|
           expr = expr.to_s unless expr.is_a?(Regexp)
           if @__exp_buffer.match(expr)
-            match_object = Expect::Match.new(expr, @__exp_buffer)
-            block.call
+            result = block.call
+            match_object = result.eql?('exp_continue') ? nil : Expect::Match.new(expr, @__exp_full_buffer)
+            break # don't try to match more than one
           end
         end
       end
@@ -50,33 +53,63 @@ module Behavior
       @exp_match
     end
 
+    ##
+    # reset timeout and continue expect loop
+    def expect_continue
+      init_timeout
+      @__exp_buffer = '' # avoid matching the same text twice
+      "exp_continue"
+    end
+    alias_method :exp_continue, :expect_continue
+    alias_method :reset_timeout, :expect_continue
+
     def execute_expect_loop
-      begin
-        Timeout::timeout(@exp_timeout_sec) do
-          @exp_match = nil
-          while exp_registered_matches.nil? do
-            raise unless respond_to?(:exp_buffer)
-            raise unless respond_to?(:exp_process)
-            exp_process
-            @__exp_buffer << exp_buffer.to_s
+      init_timeout
+      @exp_match = nil
+      result = nil
+      @__exp_buffer = ''
+      @__exp_full_buffer = ''
+      while result.nil?
+        if timeout?
+          result = @exp_timeout_block.nil? ? timeout_action_default : @exp_timeout_block.call
+        else
+          raise unless respond_to?(:exp_buffer)
+          raise unless respond_to?(:exp_process)
+          # call process/buffer and then check for match
+          exp_process
+          newbuffertext = exp_buffer.to_s
+          @__exp_buffer << newbuffertext
+          @__exp_full_buffer << newbuffertext
+          if exp_registered_matches
+            result = @exp_match
+          else
+            sleep(@exp_sleep_interval_sec)
           end
         end
-        @exp_match
-      rescue Timeout::Error => e
-        @exp_timeout_block.nil? ? timeout_action_default : @exp_timeout_block.call
       end
+      result
     end
 
     def initialize_expect
       @exp_match_registry ||= {}
       @exp_match = nil
+      @exp_sleep_interval_sec ||= EXP_SLEEP_INTERVAL_SEC_DEFAULT
       @exp_timeout_sec ||= EXP_TIMEOUT_SEC_DEFAULT
       @exp_timeout_block ||= nil
       @__exp_buffer ||= ''
+      @__exp_full_buffer ||= ''
+    end
+
+    def init_timeout
+      @start_time = Time.now
+    end
+
+    def timeout?
+      (Time.now - @start_time) > @exp_timeout_sec
     end
 
     def timeout_action_default
-      raise(TimeoutError)
+      raise(TimeoutError, "Expect Timeout [start_time=#{@start_time}] [time=#{Time.now}]")
     end
 
     def when_matching(expression, &block)

--- a/test/test_expect_behaviors.rb
+++ b/test/test_expect_behaviors.rb
@@ -134,6 +134,41 @@ class TestExpectBehaviors < Test::Unit::TestCase
       assert_equal('timed out', result.to_s)
     end
 
+    should "not timeout for switch-prompt2# if expect_continue for blip" do
+      @includer.wait_sec = 1
+      result = @includer.expect do
+        when_matching(/switch-prompt2#/) do
+          @exp_match
+        end
+        when_matching(/blip/) do
+          exp_continue
+        end
+        when_timeout(4) do
+          "timed out"
+        end
+      end
+      expected = "the sun is a mass\nof incandescent gas\nswitch-prompt#\nblip blip\nblah blah\nswitch-prompt2#"
+      assert_equal(expected, result.to_s)
+    end
+
+    should "timeout for switch-prompt2# if expect_continue for incandescent" do
+      @includer.wait_sec = 1
+      result = @includer.expect do
+        when_matching(/switch-prompt2#/) do
+          @exp_match
+        end
+        when_matching(/incandescent/) do
+          exp_continue
+        end
+        when_timeout(3) do
+          "timed out"
+        end
+      end
+      expected = "timed out"
+      assert_equal(expected, result.to_s)
+    end
+
+
   end
 
 end


### PR DESCRIPTION
- if we call exp_continue, the timeout will reset
- and expect_buffer gets trimmed (only for matching) so that we don't
  reset the timeout twice for the same text
- a full buffer value was added so that we still return a match against
  full buffer
